### PR TITLE
feature/logout

### DIFF
--- a/src/main/java/com/zerobase/fastlms/config/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/fastlms/config/SecurityConfiguration.java
@@ -45,7 +45,7 @@ public class SecurityConfiguration {
                 .logout(logout -> logout
                         .logoutUrl("/member/logout")
                         .logoutSuccessUrl("/")
-                        .permitAll()
+                        .invalidateHttpSession(true)
                 );
 
         return http.build();

--- a/src/main/java/com/zerobase/fastlms/config/UserAuthenticationFailureHandler.java
+++ b/src/main/java/com/zerobase/fastlms/config/UserAuthenticationFailureHandler.java
@@ -3,6 +3,7 @@ package com.zerobase.fastlms.config;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 
@@ -15,6 +16,12 @@ public class UserAuthenticationFailureHandler extends SimpleUrlAuthenticationFai
                                         HttpServletResponse response,
                                         AuthenticationException exception
     ) throws IOException, ServletException {
+
+        String msg = "로그인에 실패하였습니다.";
+
+        if (exception instanceof InternalAuthenticationServiceException) {
+            msg = exception.getMessage();
+        }
 
         setUseForward(true);
         setDefaultFailureUrl("/member/login?error=true");

--- a/src/main/java/com/zerobase/fastlms/member/exception/MemberNotEmailAuthException.java
+++ b/src/main/java/com/zerobase/fastlms/member/exception/MemberNotEmailAuthException.java
@@ -1,0 +1,7 @@
+package com.zerobase.fastlms.member.exception;
+
+public class MemberNotEmailAuthException extends RuntimeException {
+    public MemberNotEmailAuthException(String error) {
+    super(error);
+    }
+}

--- a/src/main/java/com/zerobase/fastlms/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/zerobase/fastlms/member/service/impl/MemberServiceImpl.java
@@ -2,6 +2,7 @@ package com.zerobase.fastlms.member.service.impl;
 
 import com.zerobase.fastlms.components.MailComponents;
 import com.zerobase.fastlms.member.entity.Member;
+import com.zerobase.fastlms.member.exception.MemberNotEmailAuthException;
 import com.zerobase.fastlms.member.model.MemberInput;
 import com.zerobase.fastlms.member.repository.MemberRepository;
 import com.zerobase.fastlms.member.service.MemberService;
@@ -90,6 +91,10 @@ public class MemberServiceImpl implements MemberService {
         }
 
         Member member = optionalMember.get();
+
+        if (!member.isEmailAuthYn()) {
+            throw new MemberNotEmailAuthException("이메일 활성화 이후에 로그인을 해주세요.");
+        }
 
         List<SimpleGrantedAuthority> grantedAuthorities = new ArrayList<>();
         grantedAuthorities.add(new SimpleGrantedAuthority("ROLE_USER"));


### PR DESCRIPTION
Changes  
---  
- 로그아웃 처리 기능 구현 (`/logout` 경로 매핑)  
- `logoutSuccessUrl` 설정을 통해 로그아웃 후 로그인 페이지로 리디렉션  
- Security 설정 변경: 메일 인증이 완료된 사용자만 로그인 가능하도록 조건 추가  
- `MemberService` 및 `UserDetailsService`에서 `emailAuthYn` 검증 로직 추가  

Description  
---  
Spring Security 기반 로그아웃 기능을 구현하였습니다.  
사용자가 로그아웃 시 세션을 종료하고, 로그인 페이지로 안전하게 리디렉션되며,  
로그아웃 URL은 기본 경로(`/logout`)로 설정되어 있습니다.

또한 이번 커밋에서는 로그인 시, **이메일 인증이 완료된 사용자만 로그인 가능**하도록  
인증 조건을 강화하였습니다.  
- DB의 `email_auth_yn` 값이 'Y'인 경우에만 인증 허용  
- 인증되지 않은 사용자는 로그인 시 실패 처리되고 메시지 출력됨  