### PR TITLE
reset-password-request

### DIFF
--- a/src/main/java/com/zerobase/fastlms/config/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/fastlms/config/SecurityConfiguration.java
@@ -34,7 +34,11 @@ public class SecurityConfiguration {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/member/register", "/member/email-auth").permitAll()
+                        .requestMatchers(
+                                "/",
+                                "/member/register",
+                                "/member/email-auth",
+                                "/member/find/password").permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(form -> form

--- a/src/main/java/com/zerobase/fastlms/member/controller/MemberController.java
+++ b/src/main/java/com/zerobase/fastlms/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.zerobase.fastlms.member.controller;
 
 import com.zerobase.fastlms.member.model.MemberInput;
+import com.zerobase.fastlms.member.model.ResetPasswordInput;
 import com.zerobase.fastlms.member.service.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,24 @@ public class MemberController {
         return "member/login";
     }
 
+    @GetMapping("/find/password")
+    public String findPassword() {
+        return "member/find_password";
+    }
+
+    @PostMapping("/find/password")
+    public String findPasswordSubmit(Model model, ResetPasswordInput parameter) {
+
+        boolean result = false;
+        try {
+            result = memberService.sendResetPassword(parameter);
+        } catch (Exception e) {
+        }
+        model.addAttribute("result", result);
+
+        return "member/find_password_result";
+    }
+
     @GetMapping("/register")
     public String register() {
         return "member/register";
@@ -31,10 +50,9 @@ public class MemberController {
     // request -> WEB -> SERVER
     // response -> SERVER -> WEB
     @PostMapping("/register")
-    public String registerSubmit(
-            Model model,
-            HttpServletRequest request,
-            MemberInput parameter
+    public String registerSubmit(Model model,
+                                 HttpServletRequest request,
+                                 MemberInput parameter
     ) {
         boolean result = memberService.register(parameter);
 

--- a/src/main/java/com/zerobase/fastlms/member/entity/Member.java
+++ b/src/main/java/com/zerobase/fastlms/member/entity/Member.java
@@ -27,4 +27,7 @@ public class Member {
     private LocalDateTime emailAuthDt;
     private String emailAuthKey;
 
+    private String resetPasswordKey;
+    private LocalDateTime resetPasswordLimitDt;
+
 }

--- a/src/main/java/com/zerobase/fastlms/member/model/ResetPasswordInput.java
+++ b/src/main/java/com/zerobase/fastlms/member/model/ResetPasswordInput.java
@@ -1,0 +1,13 @@
+package com.zerobase.fastlms.member.model;
+
+import lombok.Data;
+import lombok.ToString;
+
+@ToString
+@Data
+public class ResetPasswordInput {
+
+    private String userId;
+    private String userName;
+
+}

--- a/src/main/java/com/zerobase/fastlms/member/repository/MemberRepository.java
+++ b/src/main/java/com/zerobase/fastlms/member/repository/MemberRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, String> {
 
     Optional<Member> findByEmailAuthKey(String emailAuthKey);
+
+    Optional<Member> findByUserIdAndUserName(String userId, String userName);
 }

--- a/src/main/java/com/zerobase/fastlms/member/service/MemberService.java
+++ b/src/main/java/com/zerobase/fastlms/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.zerobase.fastlms.member.service;
 
 import com.zerobase.fastlms.member.model.MemberInput;
+import com.zerobase.fastlms.member.model.ResetPasswordInput;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
 public interface MemberService extends UserDetailsService {
@@ -11,4 +12,9 @@ public interface MemberService extends UserDetailsService {
      * uuid에 해당하는 계정을 활성화 함.
      */
     boolean emailAuth(String uuid);
+
+    /**
+     * 입력한 이메일로 비밀번호 초기화 정보를 전송
+     */
+    boolean sendResetPassword(ResetPasswordInput parameter);
 }

--- a/src/main/java/com/zerobase/fastlms/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/zerobase/fastlms/member/service/impl/MemberServiceImpl.java
@@ -4,6 +4,7 @@ import com.zerobase.fastlms.components.MailComponents;
 import com.zerobase.fastlms.member.entity.Member;
 import com.zerobase.fastlms.member.exception.MemberNotEmailAuthException;
 import com.zerobase.fastlms.member.model.MemberInput;
+import com.zerobase.fastlms.member.model.ResetPasswordInput;
 import com.zerobase.fastlms.member.repository.MemberRepository;
 import com.zerobase.fastlms.member.service.MemberService;
 import lombok.Generated;
@@ -58,9 +59,9 @@ public class MemberServiceImpl implements MemberService {
         );
 
         String email = parameter.getUserId();
-        String subject = "fastums 사이트 가입을 축하드립니다. ";
-        String text = "<p>fastums 사이트 가입을 축하드립니다.</p><p>아래 링크를 클릭하셔서 가입을 완료 하세요. </p>"
-                + "<div><a target='_blank' href='http://localhost: 8080/member/email-auth?id=" + uuid + "> 가입 완료 </a></div>";
+        String subject = "[fastums] 사이트 가입을 축하드립니다. ";
+        String text = "<p>[fastums] 사이트 가입을 축하드립니다.</p><p>아래 링크를 클릭하셔서 가입을 완료 하세요. </p>"
+                + "<div><a target='_blank' href='http://localhost:8080/member/email-auth?id=" + uuid + "> 가입 완료 </a></div>";
         mailComponents.sendMail(email, subject, text);
 
         return true;
@@ -78,6 +79,31 @@ public class MemberServiceImpl implements MemberService {
         member.setEmailAuthYn(true);
         member.setEmailAuthDt(LocalDateTime.now());
         memberRepository.save(member);
+
+        return true;
+    }
+
+    @Override
+    public boolean sendResetPassword(ResetPasswordInput parameter) {
+        Optional<Member> optionalMember = memberRepository.findByUserIdAndUserName(
+                parameter.getUserId(), parameter.getUserName());
+        if (!optionalMember.isPresent()) {
+            throw new UsernameNotFoundException("회원 정보가 존재하지 않습니다.");
+        }
+
+        Member member = optionalMember.get();
+
+        String uuid = UUID.randomUUID().toString();
+
+        member.setResetPasswordKey(uuid);
+        member.setResetPasswordLimitDt(LocalDateTime.now().plusDays(1));
+        memberRepository.save(member);
+
+        String email = parameter.getUserId();
+        String subject = "[fastums] 비밀번호 초기화 메일입니다. ";
+        String text = "<p>[fastums] 비밀번호 초기화 메일입니다. </p><p>아래 링크를 클릭하셔서 비밀번호를 초기화 하세요. </p>"
+                + "<div><a target='_blank' href='http://localhost:8080/member/reset/password?id=" + uuid + "> 비밀번호 초기화 링크 </a></div>";
+        mailComponents.sendMail(email, subject, text);
 
         return true;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,3 +21,7 @@ spring:
         smtp:
           starttls:
             enable: true
+
+logging:
+  level:
+    root: info

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>fastlms</title>
+</head>
+<body>
+
+    <div th:fragment="fragment-body-menu">
+        <div>
+            <a href="/member/register">회원 가입</a>
+            |
+            <a href="/member/info">회원 정보</a>
+            |
+            <a href="/member/login">로그인</a>
+            |
+            <a href="/member/logout">로그아웃</a>
+        </div>
+        <hr/>
+    </div>
+
+
+
+</body>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,22 +1,13 @@
 <!doctype html>
 <html lang="ko">
 <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" xmlns:th="http://www.thymeleaf.org">
     <title>메인 페이지</title>
 </head>
 <body>
-<h1> 메인 페이지 !!!</h1>
+    <h1> 메인 페이지 !!!</h1>
 
-<div>
-    <a href="/member/register">회원 가입</a>
-    |
-    <a href="/member/info">회원 정보</a>
-    |
-    <a href="/member/login">로그인</a>
-    |
-    <a href="/member/logout">로그아웃</a>
-</div>
-<hr/>
+    <div th:replace="fragments/layout.html :: fragment-body-menu"></div>
 
 </body>
 </html>

--- a/src/main/resources/templates/member/find_password.html
+++ b/src/main/resources/templates/member/find_password.html
@@ -2,11 +2,11 @@
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>회원 로그인</title>
+    <title>회원 비밀번호 찾기</title>
 </head>
 <body>
 
-    <h1>회원 로그인</h1>
+    <h1>회원 비밀번호 찾기</h1>
     <div th:replace="fragments/layout.html :: fragment-body-menu"></div>
 
     <form method="post">
@@ -15,17 +15,13 @@
             <input type="email" name="userId" placeholder="아이디(이메일) 입력" required />
         </div>
         <div>
-            <input type="password" name="password" placeholder="비밀번호 입력" required />
+            <input type="text" name="userName" placeholder="이름 입력" required />
         </div>
         <div>
-            <button>로그인</button>
+            <button>비밀번호 초기화 요청</button>
         </div>
 
     </form>
-
-    <div>
-        <a href="/member/find/password">비밀번호 찾기</a>
-    </div>
 
 </body>
 </html>

--- a/src/main/resources/templates/member/find_password_result.html
+++ b/src/main/resources/templates/member/find_password_result.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>회원 비밀번호 찾기 요청 결과</title>
+</head>
+<body>
+
+    <h1>회원 비밀번호 찾기 요청 결과</h1>
+    <div th:replace="fragments/layout.html :: fragment-body-menu"></div>
+
+
+
+    <div th:if="${result eq true}">
+        <P>입력하신 이메일로 비밀본호 초기화 정보를 보내드렸습니다.</P>
+    </div>
+
+    <div th:if="${result eq false}">
+        <p>요청하신 정보가 존재하지 않습니다.</p>
+            <a href="/member/find_password">다시 시도</a>
+    </div>
+
+
+</body>
+</html>

--- a/src/main/resources/templates/member/info.html
+++ b/src/main/resources/templates/member/info.html
@@ -7,6 +7,6 @@
 <body>
 
     <h1>회원 정보</h1>
-
+    <div th:replace="fragments/layout.html :: fragment-body-menu"></div>
 </body>
 </html>

--- a/src/main/resources/templates/member/register.html
+++ b/src/main/resources/templates/member/register.html
@@ -6,6 +6,7 @@
 </head>
 <body>
     <h1>회원 가입</h1>
+    <div th:replace="fragments/layout.html :: fragment-body-menu"></div>
 
     <!--
     아이디(이메일), 이름, 전화번호, 비밀번호

--- a/src/main/resources/templates/member/register_complete.html
+++ b/src/main/resources/templates/member/register_complete.html
@@ -8,11 +8,13 @@
 
 <div th:if="${result}">
     <h1>회원 가입 완료</h1>
+    <div th:replace="fragments/layout.html :: fragment-body-menu"></div>
     <p>회원 가입 완료되었습니다.</p>
 </div>
 
 <div th:if="${result eq false}">
     <h1>회원 가입 결과</h1>
+    <div th:replace="fragments/layout.html :: fragment-body-menu"></div>
     <p>회원 가입에 실패하였습니다.</p>
 </div>
 


### PR DESCRIPTION
Changes  
---  

- 비밀번호 초기화 요청 폼 (`reset-password.html`) 추가  
- 이메일 입력 시 인증 링크 발송 기능 구현  
- `MailComponents` 클래스 생성 및 SMTP 설정 적용  
- 인증 링크에 포함될 토큰 생성 로직 추가  
- 비밀번호 초기화 요청 컨트롤러 및 서비스 로직 구현  

Description  
---  

회원이 비밀번호를 잊어버렸을 경우 이메일을 통해  
비밀번호 재설정 링크를 요청할 수 있는 기능을 구현하였습니다.

이메일 입력 후 제출 시:
- 사용자 이메일 주소가 유효하면 인증 링크를 포함한 메일 발송  
- 인증 링크에는 토큰이 포함되며, 이후 비밀번호 재설정 단계에서 검증 예정  
- 토큰은 UUID 기반이며 DB 또는 메모리 저장 방식으로 관리 가능

✅ 이 PR은 **비밀번호 초기화 요청 단계까지만** 포함되며,  
실제 재설정 처리(비밀번호 변경)는 다음 브랜치에서 구현 예정입니다.