### PR TITLE
password-reset-confirm

### DIFF
--- a/src/main/java/com/zerobase/fastlms/config/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/fastlms/config/SecurityConfiguration.java
@@ -38,7 +38,8 @@ public class SecurityConfiguration {
                                 "/",
                                 "/member/register",
                                 "/member/email-auth",
-                                "/member/find/password").permitAll()
+                                "/member/find/password",
+                                "/member/reset/password").permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(form -> form

--- a/src/main/java/com/zerobase/fastlms/member/controller/MemberController.java
+++ b/src/main/java/com/zerobase/fastlms/member/controller/MemberController.java
@@ -85,4 +85,30 @@ public class MemberController {
         return "member/info";
     }
 
+    @GetMapping("/reset/password")
+    public String resetPassword(Model model, HttpServletRequest request) {
+
+        String uuid = request.getParameter("id");
+
+        boolean result = memberService.checkResetPassword(uuid);
+
+        model.addAttribute("result", result);
+
+        return "member/reset_password";
+    }
+
+    @PostMapping("/reset/password")
+    public String resetPasswordSubmit(Model model, ResetPasswordInput parameter) {
+
+        boolean result = false;
+
+        try {
+            result = memberService.resetPassword(parameter.getId(), parameter.getPassword());
+        } catch (Exception e) {
+        }
+
+        model.addAttribute("result", result);
+
+        return "member/reset_password_result";
+    }
 }

--- a/src/main/java/com/zerobase/fastlms/member/model/ResetPasswordInput.java
+++ b/src/main/java/com/zerobase/fastlms/member/model/ResetPasswordInput.java
@@ -10,4 +10,7 @@ public class ResetPasswordInput {
     private String userId;
     private String userName;
 
+    private  String id;
+    private String password;
+
 }

--- a/src/main/java/com/zerobase/fastlms/member/repository/MemberRepository.java
+++ b/src/main/java/com/zerobase/fastlms/member/repository/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository extends JpaRepository<Member, String> {
     Optional<Member> findByEmailAuthKey(String emailAuthKey);
 
     Optional<Member> findByUserIdAndUserName(String userId, String userName);
+
+    Optional<Member> findByResetPasswordKey(String resetPasswordKey);
 }

--- a/src/main/java/com/zerobase/fastlms/member/service/MemberService.java
+++ b/src/main/java/com/zerobase/fastlms/member/service/MemberService.java
@@ -17,4 +17,14 @@ public interface MemberService extends UserDetailsService {
      * 입력한 이메일로 비밀번호 초기화 정보를 전송
      */
     boolean sendResetPassword(ResetPasswordInput parameter);
+
+    /**
+     * 입력 받은 uuid에 대해서 password로 초기화 함
+     */
+    boolean resetPassword(String id, String password);
+
+    /**
+     * 입력받은 uuid값이 유효한지 확인
+     */
+    boolean checkResetPassword(String uuid);
 }

--- a/src/main/resources/templates/member/find_password_result.html
+++ b/src/main/resources/templates/member/find_password_result.html
@@ -17,7 +17,9 @@
 
     <div th:if="${result eq false}">
         <p>요청하신 정보가 존재하지 않습니다.</p>
-            <a href="/member/find_password">다시 시도</a>
+    </div>
+    <div>
+        <a href="/member/find_password">다시 시도</a>
     </div>
 
 

--- a/src/main/resources/templates/member/reset_password.html
+++ b/src/main/resources/templates/member/reset_password.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>회원 비밀번호 초기화</title>
+
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"
+            integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
+    <script>
+        $(document).ready(function () {
+
+            $('form').on('submit', function () {
+                var password = $(this).find('input[name=password]').val();
+                var rePassword = $(this).find('input[name=rePassword]').val();
+
+                if (password != rePassword) {
+                    alert(' 비밀번호값하고 확인비밀번호값이 일치하지 않습니다. ');
+                    return false;
+                }
+
+            });
+
+        });
+    </script>
+</head>
+<body>
+
+    <h1>회원 비밀번호 초기화</h1>
+    <div th:if="${result eq true}">
+
+        <form method="post">
+
+            <div>
+                <input type="password" name="password" placeholder="비밀번호 입력" required/>
+            </div>
+            <div>
+                <input type="password" name="rePassword" placeholder="확인 비밀번호 입력" required/>
+            </div>
+            <div>
+                <button>비밀번호 재설정</button>
+            </div>
+
+        </form>
+
+    </div>
+    <div th:if="${result eq false}">
+        <p>입력값이 유효하지 않습니다.</p>
+        <a href="/">메인으로 이동</a>
+    </div>
+
+
+</body>
+</html>

--- a/src/main/resources/templates/member/reset_password_result.html
+++ b/src/main/resources/templates/member/reset_password_result.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>회원 비밀번호 초기화 결과</title>
+
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"
+            integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
+    <script>
+        $(document).ready(function () {
+
+            $('form').on('submit', function () {
+                var password = $(this).find('input[name=password]').val();
+                var rePassword = $(this).find('input[name=rePassword]').val();
+
+                if (password != rePassword) {
+                    alert(' 비밀번호값하고 확인비밀번호값이 일치하지 않습니다. ');
+                    return false;
+                }
+
+            });
+
+        });
+    </script>
+</head>
+<body>
+
+    <h1>회원 비밀번호 초기화 결과</h1>
+    <div th:replace="fragments/layout.html :: fragment-body-menu"></div>
+
+    <div th:if="${result eq true}">
+        <P> 비밀번호가 초기화 되었습니다.</P>
+    </div>
+    <div>
+        <a href="/member/login">로그인 하기</a>
+    </div>
+
+    <div th:if="${result eq false}">
+        <p>비밀번호 초기화에 실패하였습니다.</p>
+    </div>
+    <div>
+        <a href="/member/find_password">다시 시도</a>
+    </div>
+
+</body>
+</html>


### PR DESCRIPTION
Changes  
---  

- 비밀번호 재설정 화면 (`reset_password.html`) 추가  
- 인증 이메일에 포함된 토큰을 검증하는 컨트롤러 구현  
- 토큰 검증 성공 시 비밀번호 재입력 페이지로 이동  
- 새 비밀번호 입력 → 기존 사용자 계정에 반영되도록 처리  
- 유효하지 않거나 만료된 토큰에 대한 예외 처리 포함  
- 비밀번호 암호화 및 저장 후 로그인 페이지로 리디렉션

Description  
---  

이메일로 받은 인증 링크를 클릭했을 때,  
비밀번호를 안전하게 재설정할 수 있는 기능을 구현하였습니다.

프로세스 흐름은 다음과 같습니다:
1. 메일 링크 클릭 시, 서버에서 토큰 유효성 검사  
2. 유효하면 `reset_password.html` 페이지로 이동  
3. 새 비밀번호를 입력하면 암호화 후 DB에 저장  
4. 저장 완료 후 로그인 페이지로 리디렉션됨

토큰은 UUID 기반이며,
- 유효하지 않거나 만료된 경우 사용자에게 메시지 출력  
- 한 번 사용한 토큰은 재사용 불가능하도록 처리

✅ 이 PR은 `password-reset-request` 브랜치의 후속 작업입니다.