### PR TITLE
feature/member-status-reset

### DIFF
--- a/src/main/java/com/zerobase/fastlms/admin/controller/AdminMainController.java
+++ b/src/main/java/com/zerobase/fastlms/admin/controller/AdminMainController.java
@@ -1,4 +1,4 @@
-package com.zerobase.fastlms.admin;
+package com.zerobase.fastlms.admin.controller;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/zerobase/fastlms/admin/controller/AdminMemberController.java
+++ b/src/main/java/com/zerobase/fastlms/admin/controller/AdminMemberController.java
@@ -2,12 +2,14 @@ package com.zerobase.fastlms.admin.controller;
 
 import com.zerobase.fastlms.admin.dto.MemberDto;
 import com.zerobase.fastlms.admin.model.MemberParam;
+import com.zerobase.fastlms.admin.model.MemberInput;
 import com.zerobase.fastlms.member.service.MemberService;
 import com.zerobase.fastlms.util.PageUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.List;
@@ -40,4 +42,34 @@ public class AdminMemberController {
 
         return "admin/member/list";
     }
+
+    @GetMapping("/detail.do")
+    public String detail(Model model, MemberParam parameter) {
+
+        parameter.init();
+
+        MemberDto member = memberService.detail(parameter.getUserId());
+        model.addAttribute("member", member);
+
+        return "admin/member/detail";
+    }
+
+    @PostMapping("/status.do")
+    public String status(Model model, MemberInput parameter) {
+
+        boolean result = memberService.updateStatus(
+                parameter.getUserId(),parameter.getUserStatus());
+
+        return "redirect:/admin/member/detail.do?userId=" + parameter.getUserId();
+    }
+
+    @PostMapping("/password.do")
+    public String password(Model model, MemberInput parameter) {
+
+        boolean result = memberService.updatePassword(
+                parameter.getUserId(),parameter.getPassword());
+
+        return "redirect:/admin/member/password.do?userId=" + parameter.getUserId();
+    }
+
 }

--- a/src/main/java/com/zerobase/fastlms/admin/dto/MemberDto.java
+++ b/src/main/java/com/zerobase/fastlms/admin/dto/MemberDto.java
@@ -1,9 +1,16 @@
 package com.zerobase.fastlms.admin.dto;
 
+import com.zerobase.fastlms.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Data
 public class MemberDto {
 
@@ -21,8 +28,33 @@ public class MemberDto {
     LocalDateTime resetPasswordLimitDt;
 
     boolean adminYn;
+    String userStatus;
 
     // 추가 컬럼
     long totalCount;
     long seq;
+
+    public static MemberDto of(Member member) {
+
+        return MemberDto.builder()
+                .userId(member.getUserId())
+                .userName(member.getUserName())
+                .phone(member.getPhone())
+//                .password(member.getPassword())
+
+                .regDt(member.getRegDt())
+                .emailAuthYn(member.isEmailAuthYn())
+                .emailAuthDt(member.getEmailAuthDt())
+                .emailAuthKey(member.getEmailAuthKey())
+
+                .resetPasswordKey(member.getResetPasswordKey())
+                .resetPasswordLimitDt(member.getResetPasswordLimitDt())
+
+                .adminYn(member.isAdminYn())
+                .userStatus(member.getUserStatus())
+
+                .build();
+    }
+
+
 }

--- a/src/main/java/com/zerobase/fastlms/admin/model/MemberInput.java
+++ b/src/main/java/com/zerobase/fastlms/admin/model/MemberInput.java
@@ -1,0 +1,11 @@
+package com.zerobase.fastlms.admin.model;
+
+import lombok.Data;
+
+@Data
+public class MemberInput {
+
+    String userId;
+    String userStatus;
+    String password;
+}

--- a/src/main/java/com/zerobase/fastlms/admin/model/MemberParam.java
+++ b/src/main/java/com/zerobase/fastlms/admin/model/MemberParam.java
@@ -11,6 +11,8 @@ public class MemberParam {
     String searchType;
     String searchValue;
 
+    String userId;
+
     /*
     limit 0, 10 --> pageIndex: 1
     limit 10, 10 --> pageIndex: 2

--- a/src/main/java/com/zerobase/fastlms/member/entity/Member.java
+++ b/src/main/java/com/zerobase/fastlms/member/entity/Member.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @Builder
@@ -14,7 +15,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Data
 @Entity
-public class Member {
+public class Member implements MemberCode {
 
     @Id
     private String userId;
@@ -33,4 +34,5 @@ public class Member {
 
     private boolean adminYn;
 
+    private String userStatus; // 이용 가능한 상태, 정지 상태
 }

--- a/src/main/java/com/zerobase/fastlms/member/entity/MemberCode.java
+++ b/src/main/java/com/zerobase/fastlms/member/entity/MemberCode.java
@@ -1,0 +1,19 @@
+package com.zerobase.fastlms.member.entity;
+
+public interface MemberCode {
+
+    /**
+     * 현재 가입 요청중
+     */
+    String MEMBER_STATUS_REQ = "REQ";
+
+    /**
+     * 현재 이용중인 상태
+     */
+    String MEMBER_STATUS_ING = "ING";
+
+    /**
+     * 현재 정지된 상태
+     */
+    String MEMBER_STATUS_STOP = "STOP";
+}

--- a/src/main/java/com/zerobase/fastlms/member/exception/MemberStopUserException.java
+++ b/src/main/java/com/zerobase/fastlms/member/exception/MemberStopUserException.java
@@ -1,0 +1,7 @@
+package com.zerobase.fastlms.member.exception;
+
+public class MemberStopUserException extends RuntimeException {
+    public MemberStopUserException(String error) {
+    super(error);
+    }
+}

--- a/src/main/java/com/zerobase/fastlms/member/repository/MemberRepository.java
+++ b/src/main/java/com/zerobase/fastlms/member/repository/MemberRepository.java
@@ -2,9 +2,11 @@ package com.zerobase.fastlms.member.repository;
 
 import com.zerobase.fastlms.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface MemberRepository extends JpaRepository<Member, String> {
 
     Optional<Member> findByEmailAuthKey(String emailAuthKey);

--- a/src/main/java/com/zerobase/fastlms/member/service/MemberService.java
+++ b/src/main/java/com/zerobase/fastlms/member/service/MemberService.java
@@ -37,4 +37,19 @@ public interface MemberService extends UserDetailsService {
      * 회원 목록 리턴(관리자에서만 사용 가능)
      */
     List<MemberDto> list(MemberParam parameter);
+
+    /**
+     * 회원 상세 정보
+     */
+    MemberDto detail(String userId);
+
+    /**
+     * 회원 상태 변경
+     */
+    boolean updateStatus(String userId, String userStatus);
+
+    /**
+     * 회원 비밀번호 초기화
+     */
+    boolean updatePassword(String userId, String password);
 }

--- a/src/main/resources/templates/admin/member/detail.html
+++ b/src/main/resources/templates/admin/member/detail.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>관리자 화면</title>
+    <style>
+        .detail table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        .detail table th, .detail table td {
+            border: 1px solid #000;
+        }
+    </style>
+</head>
+<body>
+    <h1> 관리자 회원 관리 - 회원 상세 정보</h1>
+    <div>
+        <a href="/admin/admin/main.do"> 관리자 메인 </a>
+        |
+        <a href="/admin/member/list.do"> 회원 관리 </a>
+        |
+        <a href="#"> 카테고리 관리 </a>
+        |
+        <a href="#"> 강의 관리 </a>
+        |
+        <a href="/member/logout"> 로그아웃 </a>
+        <dr/>
+        <hr/>
+    </div>
+
+    <div class="detail">
+
+        <table>
+            <tbody>
+            <tr>
+                <th>아이디</th>
+                <td>
+                    <p th:text="${member.userId}"></p>
+                </td>
+            </tr>
+            <tr>
+                <th>이름</th>
+                <td>
+                    <p th:text="${member.userName}"></p>
+                </td>
+            </tr>
+            <tr>
+                <th>연락처</th>
+                <td>
+                    <p th:text="${member.phone}"></p>
+                </td>
+            </tr>
+            <tr>
+                <th>가입일</th>
+                <td>
+                    <p th:text="${member.regDt}"></p>
+                </td>
+            </tr>
+            <tr>
+                <th>이메일 인증</th>
+                <td>
+                    <p th:text="${member.emailAuthYn}"></p>
+                </td>
+            </tr>
+            <tr>
+                <th>관리자 여부</th>
+                <td>
+                    <p th:text="${member.adminYn}"></p>
+                </td>
+            </tr>
+            <tr>
+                <th>회원 상태</th>
+                <td>
+                    <p>
+                        현재상태: <span th:text="${member.userStatus}"></span>
+                    </p>
+                    <div>
+                        <form method="post" action="/admin/member/status.do">
+                            <input th:value="${member.userId}" type="hidden" name="memberId" >
+                            <select name="userStatus">
+                                <option value="REQ">가입승인중</option>
+                                <option value="ING">정상이용중</option>
+                                <option value="STOP">정지중</option>
+                            </select>
+                            <button type="submit">상태 변경</button>
+                        </form>
+                    </div>
+                </td>
+            </tr>
+
+            <tr>
+                <th>회원 비밀번호 초기화</th>
+                <td>
+                    <div>
+                        <form method="post" action="/admin/member/password.do">
+                            <input th:value="${member.userId}" type="hidden" name="memberId" >
+                            <input type="text" name="password" >
+                            <button type="submit">비밀번호 초기화</button>
+                        </form>
+                    </div>
+                </td>
+            </tr>
+
+            </tbody>
+        </table>
+
+
+        <div>
+            <a href="list.do"> 목록 </a>
+        </div>
+
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/member/list.html
+++ b/src/main/resources/templates/admin/member/list.html
@@ -95,9 +95,13 @@
                 </tr>
             </thead>
             <tbody>
-                <tr>
-                    <td>1</td>
-                    <td th:text="${x.userId}">education.leochoi@gmail.com</td>
+                <tr th:each="x : ${list}">
+                    <td th:text="${x.seq}">1</td>
+                    <td>
+                        <a th:text="${x.userId}"
+                           th:href="${'detail.do?userid=' + x.userId}">
+                           education.leochoi@gmail.com</a>
+                    </td>
                     <td th:text="${x.userName}">홍길동</td>
                     <td th:text="${x.phone}">010-1111-2222</td>
                     <td>


### PR DESCRIPTION
Changes  
---  

- 회원 상세 목록 페이지 구현 (`admin/member/detail.html`)  
- 회원 상태(status) 수정 기능 추가 (진행중/정상/정지 등)  
- 관리자 전용 비밀번호 초기화 버튼 구현  
- 비밀번호 초기화 시 이메일 발송 + 토큰 생성 로직 재활용  
- 상태값 변경 시 DB 반영 및 UI에 알림 출력  
- 관련 컨트롤러, 서비스, Mapper 메서드 추가  

Description  
---  

관리자가 회원의 상세 정보를 조회하고  
회원 상태를 변경하거나 비밀번호 초기화를 요청할 수 있는 기능을 구현하였습니다.

- 회원 상세 페이지에서 사용자 상태를 선택 후 변경 가능  
- 상태 변경 시 즉시 DB 반영 및 상태값 갱신  
- 비밀번호 초기화 버튼 클릭 시 인증 메일 자동 발송  
- 이전에 구현한 이메일 인증/토큰 로직을 재사용하여 연동 처리  
- 전체 기능은 관리자 전용 영역에서만 접근 가능