### PR TITLE
feature/category-management

### DIFF
--- a/src/main/java/com/zerobase/fastlms/admin/controller/AdminCategoryController.java
+++ b/src/main/java/com/zerobase/fastlms/admin/controller/AdminCategoryController.java
@@ -1,0 +1,53 @@
+package com.zerobase.fastlms.admin.controller;
+
+import com.zerobase.fastlms.admin.dto.CategoryDto;
+import com.zerobase.fastlms.admin.model.CategoryInput;
+import com.zerobase.fastlms.admin.model.MemberParam;
+import com.zerobase.fastlms.admin.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/admin/category")
+@Controller
+public class AdminCategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping("/list.do")
+    public String list(Model model, MemberParam parameter) {
+
+        List<CategoryDto> list = categoryService.list();
+        model.addAttribute("list", list);
+
+        return "admin/category/list";
+    }
+
+    @PostMapping("/add.do")
+    public String add(Model model, CategoryInput parameter) {
+        boolean result = categoryService.add(parameter.getCategoryName());
+
+        return "redirect:/admin/category/list.do";
+    }
+
+    @PostMapping("/delete.do")
+    public String del(Model model, CategoryInput parameter) {
+        boolean result = categoryService.del(parameter.getId());
+
+        return "redirect:/admin/category/list.do";
+    }
+
+    @PostMapping("/update.do")
+    public String update(Model model, CategoryInput parameter) {
+        boolean result = categoryService.update(parameter);
+
+        return "redirect:/admin/category/list.do";
+    }
+
+}

--- a/src/main/java/com/zerobase/fastlms/admin/controller/AdminMemberController.java
+++ b/src/main/java/com/zerobase/fastlms/admin/controller/AdminMemberController.java
@@ -1,8 +1,8 @@
 package com.zerobase.fastlms.admin.controller;
 
 import com.zerobase.fastlms.admin.dto.MemberDto;
-import com.zerobase.fastlms.admin.model.MemberParam;
 import com.zerobase.fastlms.admin.model.MemberInput;
+import com.zerobase.fastlms.admin.model.MemberParam;
 import com.zerobase.fastlms.member.service.MemberService;
 import com.zerobase.fastlms.util.PageUtil;
 import lombok.RequiredArgsConstructor;
@@ -58,7 +58,7 @@ public class AdminMemberController {
     public String status(Model model, MemberInput parameter) {
 
         boolean result = memberService.updateStatus(
-                parameter.getUserId(),parameter.getUserStatus());
+                parameter.getUserId(), parameter.getUserStatus());
 
         return "redirect:/admin/member/detail.do?userId=" + parameter.getUserId();
     }
@@ -67,7 +67,7 @@ public class AdminMemberController {
     public String password(Model model, MemberInput parameter) {
 
         boolean result = memberService.updatePassword(
-                parameter.getUserId(),parameter.getPassword());
+                parameter.getUserId(), parameter.getPassword());
 
         return "redirect:/admin/member/password.do?userId=" + parameter.getUserId();
     }

--- a/src/main/java/com/zerobase/fastlms/admin/dto/CategoryDto.java
+++ b/src/main/java/com/zerobase/fastlms/admin/dto/CategoryDto.java
@@ -1,0 +1,45 @@
+package com.zerobase.fastlms.admin.dto;
+
+import com.zerobase.fastlms.admin.entity.Category;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class CategoryDto {
+
+    Long id;
+    String categoryName;
+    int sortValue;
+    boolean usingYn;
+
+    public static List<CategoryDto> of(List<Category> categories) {
+        if (categories != null) {
+            List<CategoryDto> categoryList = new ArrayList<>();
+            for (Category x : categories) {
+                categoryList.add(of(x));
+            }
+            return categoryList;
+        }
+
+        return null;
+    }
+
+    public static CategoryDto of(Category category) {
+        return CategoryDto.builder()
+                .id(category.getId())
+                .categoryName(category.getCategoryName())
+                .sortValue(category.getSortValue())
+                .usingYn(category.isUsingYn())
+                .build();
+
+    }
+
+}

--- a/src/main/java/com/zerobase/fastlms/admin/entity/Category.java
+++ b/src/main/java/com/zerobase/fastlms/admin/entity/Category.java
@@ -1,0 +1,28 @@
+package com.zerobase.fastlms.admin.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Entity
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    String categoryName;
+    int sortValue;
+    boolean usingYn;
+
+
+}

--- a/src/main/java/com/zerobase/fastlms/admin/mapper/MemberMapper.java
+++ b/src/main/java/com/zerobase/fastlms/admin/mapper/MemberMapper.java
@@ -10,6 +10,7 @@ import java.util.List;
 public interface MemberMapper {
 
     long selectListCount(MemberParam memberParam);
+
     List<MemberDto> selectList(MemberParam parameter);
 
 }

--- a/src/main/java/com/zerobase/fastlms/admin/model/CategoryInput.java
+++ b/src/main/java/com/zerobase/fastlms/admin/model/CategoryInput.java
@@ -1,0 +1,12 @@
+package com.zerobase.fastlms.admin.model;
+
+import lombok.Data;
+
+@Data
+public class CategoryInput {
+
+    long id;
+    String categoryName;
+    int sortValue;
+    boolean usingYn;
+}

--- a/src/main/java/com/zerobase/fastlms/admin/repository/CategoryRepository.java
+++ b/src/main/java/com/zerobase/fastlms/admin/repository/CategoryRepository.java
@@ -1,0 +1,13 @@
+package com.zerobase.fastlms.admin.repository;
+
+import com.zerobase.fastlms.admin.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    Optional<List<Category>> findAllOrderBySortValueDesc();
+
+}

--- a/src/main/java/com/zerobase/fastlms/admin/service/CategoryService.java
+++ b/src/main/java/com/zerobase/fastlms/admin/service/CategoryService.java
@@ -1,0 +1,26 @@
+package com.zerobase.fastlms.admin.service;
+
+import com.zerobase.fastlms.admin.dto.CategoryDto;
+import com.zerobase.fastlms.admin.model.CategoryInput;
+
+import java.util.List;
+
+public interface CategoryService {
+
+    List<CategoryDto> list();
+
+    /**
+     * 카테고리 신규 추가
+     */
+    boolean add(String categoryName);
+
+    /**
+     * 카테고리 수정
+     */
+    boolean update(CategoryInput parameter);
+
+    /**
+     * 카테고리 삭제
+     */
+    boolean del(long id);
+}

--- a/src/main/java/com/zerobase/fastlms/admin/service/CategoryServiceImpl.java
+++ b/src/main/java/com/zerobase/fastlms/admin/service/CategoryServiceImpl.java
@@ -1,0 +1,69 @@
+package com.zerobase.fastlms.admin.service;
+
+import com.zerobase.fastlms.admin.dto.CategoryDto;
+import com.zerobase.fastlms.admin.entity.Category;
+import com.zerobase.fastlms.admin.model.CategoryInput;
+import com.zerobase.fastlms.admin.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class CategoryServiceImpl implements CategoryService {
+
+
+    private final CategoryRepository categoryRepository;
+
+    private Sort getSortBySortValueDesc() {
+
+        return Sort.by(Sort.Direction.DESC, "sortValue");
+    }
+
+    @Override
+    public List<CategoryDto> list() {
+        List<Category> categories = categoryRepository.findAll(getSortBySortValueDesc());
+
+        return CategoryDto.of(categories);
+    }
+
+    @Override
+    public boolean add(String categoryName) {
+
+        Category category = Category.builder()
+                .categoryName(categoryName)
+                .usingYn(true)
+                .sortValue(0)
+                .build();
+        categoryRepository.save(category);
+
+        return true;
+    }
+
+    @Override
+    public boolean update(CategoryInput parameter) {
+
+        Optional<Category> optionalCategory = categoryRepository.findById(parameter.getId());
+        if (optionalCategory.isPresent()) {
+
+            Category category = optionalCategory.get();
+
+            category.setCategoryName(parameter.getCategoryName());
+            category.setSortValue(parameter.getSortValue());
+            category.setUsingYn(parameter.isUsingYn());
+            categoryRepository.save(category);
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean del(long id) {
+        categoryRepository.deleteById(id);
+
+        return true;
+    }
+}

--- a/src/main/java/com/zerobase/fastlms/components/MailComponents.java
+++ b/src/main/java/com/zerobase/fastlms/components/MailComponents.java
@@ -28,7 +28,7 @@ public class MailComponents {
 
         boolean result = false;
 
-        MimeMessagePreparator  msg = new MimeMessagePreparator() {
+        MimeMessagePreparator msg = new MimeMessagePreparator() {
 
             @Override
             public void prepare(MimeMessage mimeMessage) throws Exception {
@@ -42,7 +42,7 @@ public class MailComponents {
         try {
             javaMailSender.send(msg);
             result = true;
-        }catch (Exception e) {
+        } catch (Exception e) {
             System.out.println(e.getMessage());
         }
 

--- a/src/main/java/com/zerobase/fastlms/main/controller/MainController.java
+++ b/src/main/java/com/zerobase/fastlms/main/controller/MainController.java
@@ -12,14 +12,9 @@ package com.zerobase.fastlms.main.controller;
 // http://localhost:8080/
 
 import com.zerobase.fastlms.components.MailComponents;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
-
-import java.io.IOException;
-import java.io.PrintWriter;
 
 @RequiredArgsConstructor
 @Controller

--- a/src/main/java/com/zerobase/fastlms/member/entity/Member.java
+++ b/src/main/java/com/zerobase/fastlms/member/entity/Member.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 
 @Builder

--- a/src/main/java/com/zerobase/fastlms/member/exception/MemberNotEmailAuthException.java
+++ b/src/main/java/com/zerobase/fastlms/member/exception/MemberNotEmailAuthException.java
@@ -2,6 +2,6 @@ package com.zerobase.fastlms.member.exception;
 
 public class MemberNotEmailAuthException extends RuntimeException {
     public MemberNotEmailAuthException(String error) {
-    super(error);
+        super(error);
     }
 }

--- a/src/main/java/com/zerobase/fastlms/member/exception/MemberStopUserException.java
+++ b/src/main/java/com/zerobase/fastlms/member/exception/MemberStopUserException.java
@@ -2,6 +2,6 @@ package com.zerobase.fastlms.member.exception;
 
 public class MemberStopUserException extends RuntimeException {
     public MemberStopUserException(String error) {
-    super(error);
+        super(error);
     }
 }

--- a/src/main/java/com/zerobase/fastlms/member/model/ResetPasswordInput.java
+++ b/src/main/java/com/zerobase/fastlms/member/model/ResetPasswordInput.java
@@ -10,7 +10,7 @@ public class ResetPasswordInput {
     private String userId;
     private String userName;
 
-    private  String id;
+    private String id;
     private String password;
 
 }

--- a/src/main/java/com/zerobase/fastlms/member/service/MemberService.java
+++ b/src/main/java/com/zerobase/fastlms/member/service/MemberService.java
@@ -2,7 +2,6 @@ package com.zerobase.fastlms.member.service;
 
 import com.zerobase.fastlms.admin.dto.MemberDto;
 import com.zerobase.fastlms.admin.model.MemberParam;
-import com.zerobase.fastlms.member.entity.Member;
 import com.zerobase.fastlms.member.model.MemberInput;
 import com.zerobase.fastlms.member.model.ResetPasswordInput;
 import org.springframework.security.core.userdetails.UserDetailsService;

--- a/src/main/java/com/zerobase/fastlms/util/PageUtil.java
+++ b/src/main/java/com/zerobase/fastlms/util/PageUtil.java
@@ -18,7 +18,7 @@ public class PageUtil {
     private long pageBlockSize = 10;
 
     /**
-     *  현재 페이지 번호
+     * 현재 페이지 번호
      */
     private long pageIndex;
 
@@ -92,7 +92,7 @@ public class PageUtil {
         sb.append(String.format("<a href='?pageIndex=%d%s'>&lt;</a>", previousPageIndex, addQueryString));
         sb.append(System.lineSeparator());
 
-        for(long i = startPage; i<= endPage; i++) {
+        for (long i = startPage; i <= endPage; i++) {
             if (i == pageIndex) {
                 sb.append(String.format("<a class='on' href='?pageIndex=%d%s'>%d</a>", i, addQueryString, i));
             } else {
@@ -128,7 +128,6 @@ public class PageUtil {
             endPage = totalBlockCount;
         }
     }
-
 
 
 }

--- a/src/main/java/com/zerobase/fastlms/util/PageUtilTest.java
+++ b/src/main/java/com/zerobase/fastlms/util/PageUtilTest.java
@@ -14,7 +14,4 @@ public class PageUtilTest {
     }
 
 
-
-
-
 }

--- a/src/main/resources/templates/admin/category/list.html
+++ b/src/main/resources/templates/admin/category/list.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>관리자 화면</title>
+    <style>
+        .lsit table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        .lsit table th, .list table td {
+            border: 1px solid #000;
+        }
+        p.nothing {
+            text-align: center;
+            padding: 100px;
+        }
+        .inline-div {
+            display: inline-block;
+        }
+
+    </style>
+
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
+    <script>
+
+        $(document).ready(function () {
+
+            $('form[name=deleteForm]').on('submit', function () {
+                if (!confirm(`카테고리를 삭제하시겠습니까?`)) {
+                    return false;
+                }
+            });
+
+            $(`button.update-button`).on('click', function () {
+
+                if(!confirm(`카테고리를 수정하시겠습니까?`)) {
+                    return false;
+                }
+
+                var $this = $(this);
+
+                var $tr = $this.closest('tr');
+
+                var id = $tr.find('input[name=id]').val();
+                var categoryName = $tr.find('input[name=categoryName]').val();
+                var sortValue = $tr.find('input[name=sortValue]').val();
+                var usingYn = $tr.find('input[type=checkbox]')[0].checked;
+
+                $updateForm = $('form[name=updateForm]');
+                $updateForm.find('input[name=id]').val(id);
+                $updateForm.find('input[name=categoryName]').val(categoryName);
+                $updateForm.find('input[name=sortValue]').val(sortValue);
+                $updateForm.find('input[name=usingYn]').val(usingYn);
+                $updateForm.submit();
+
+            });
+        });
+    </script>
+</head>
+<body>
+    <h1> 카테고리 관리</h1>
+    <div th:replace="fragments/layout.html :: fragment-admin-body-menu"></div>
+
+    <div class="lsit">
+
+        <div>
+            <form method="post" action="/admin/category/add.do">
+                <input type="text" name="categoryName" required placeholder="카테고리 입력"/>
+                <button type="submit"> 추가 </button>
+            </form>
+        </div>
+
+        <table>
+            <thead>
+                <tr>
+                    <th> ID </th>
+                    <th>
+                        카테고리명
+                    </th>
+                    <th>
+                        순서
+                    </th>
+
+                </tr>
+            </thead>
+            <tbody>
+                <tr th:each="x : ${list}">
+                    <td th:text="${x.id}">
+                        <input type="hidden" th:value="${x.id}" name="id"/>
+                        <p th:text="${x.id}">1</p>
+                    </td>
+
+                    <td>
+                        <input th:value="${x.categoryName}" type="text" name="categoryName"/>"
+                    </td>
+                    <td>
+                        <input th:value="${x.sortValue}" type="text" name="sortValue"/>
+                    </td>
+                    <td>
+                        <input th:checked="${x.usingYn}" type="checkbox" th:id="'usingYn_' + ${x.id}" th:name="'usingYn_' + ${x.id}" value="true"/>
+                        <label th:for="'usingYn_' + ${x.id}">사용</label>
+                    </td>
+                    <td>
+                        <div class="inline-div">
+                            <button class="update-button" type="button">수정</button>
+                        </div>
+                        <div class="inline-div">
+                            <form name="deleteForm" method="post" action="/admin/category/delete.do">
+                                <input type="hidden" name="id" th:value="${x.id}">
+                                <button type="submit">삭제</button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+                <tr th:if="${#lists.size(list) < 1}">
+                    <td colspan="5">
+                        <p class="nothing">내용이 없습니다.</p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+
+    </div>
+
+    <form name="updateForm" method="post" action="/admin/category/update.do">
+        <input type="hidden" name="id"/>
+        <input type="hidden" name="categoryName"/>
+        <input type="hidden" name="sortValue"/>
+        <input type="hidden" name="usingYn"/>
+    </form>
+
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/main.html
+++ b/src/main/resources/templates/admin/main.html
@@ -1,25 +1,12 @@
 <!doctype html>
-<html lang="ko">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
-    <meta charset="UTF-8" xmlns:th="http://www.thymeleaf.org">
+    <meta charset="UTF-8">
     <title>관리자 화면</title>
 </head>
 <body>
     <h1> 관리자 메인 화면</h1>
-
-        <div>
-            <a href="/admin/admin/main.do"> 관리자 메인 </a>
-            |
-            <a href="/admin/member/list.do"> 회원 관리 </a>
-            |
-            <a href="#"> 카테고리 관리 </a>
-            |
-            <a href="#"> 강의 관리 </a>
-            |
-            <a href="/member/logout"> 로그아웃 </a>
-
-        </div>
-        <hr/>
+    <div th:replace="fragments/layout.html :: fragment-admin-body-menu"></div>
 
 </body>
 </html>

--- a/src/main/resources/templates/admin/member/detail.html
+++ b/src/main/resources/templates/admin/member/detail.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="ko">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <title>관리자 화면</title>
@@ -16,19 +16,7 @@
 </head>
 <body>
     <h1> 관리자 회원 관리 - 회원 상세 정보</h1>
-    <div>
-        <a href="/admin/admin/main.do"> 관리자 메인 </a>
-        |
-        <a href="/admin/member/list.do"> 회원 관리 </a>
-        |
-        <a href="#"> 카테고리 관리 </a>
-        |
-        <a href="#"> 강의 관리 </a>
-        |
-        <a href="/member/logout"> 로그아웃 </a>
-        <dr/>
-        <hr/>
-    </div>
+    <div th:replace="fragments/layout.html :: fragment-admin-body-menu"></div>
 
     <div class="detail">
 

--- a/src/main/resources/templates/admin/member/list.html
+++ b/src/main/resources/templates/admin/member/list.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="ko">
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <title>관리자 화면</title>
@@ -8,11 +8,9 @@
             width: 100%;
             border-collapse: collapse;
         }
-
         .lsit table th, .list table td {
             border: 1px solid #000;
         }
-
         .search-form {
             position: relative;
             padding: 5px 0 10px 0;
@@ -24,7 +22,6 @@
             height: 20px;
             float: right;
         }
-
         .pager {
             margin-top: 10px;
             text-align: center;
@@ -37,19 +34,7 @@
 </head>
 <body>
     <h1> 관리자 회원 관리</h1>
-    <div>
-        <a href="/admin/admin/main.do"> 관리자 메인 </a>
-        |
-        <a href="/admin/member/list.do"> 회원 관리 </a>
-        |
-        <a href="#"> 카테고리 관리 </a>
-        |
-        <a href="#"> 강의 관리 </a>
-        |
-        <a href="/member/logout"> 로그아웃 </a>
-        <dr/>
-        <hr/>
-    </div>
+    <div th:replace="fragments/layout.html :: fragment-admin-body-menu"></div>
 
     <div class="lsit">
 
@@ -73,7 +58,7 @@
         <table>
             <thead>
                 <tr>
-                    <th>NO</th>
+                    <th> NO </th>
                     <th>
                         아이디(이메일)
                     </th>

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -20,6 +20,19 @@
     </div>
 
 
+    <div th:fragment="fragment-admin-body-menu">
+        <a href="/admin/admin/main.do"> 관리자 메인 </a>
+        |
+        <a href="/admin/member/list.do"> 회원 관리 </a>
+        |
+        <a href="/admin/category/list.do"> 카테고리 관리 </a>
+        |
+        <a href="#"> 강의 관리 </a>
+        |
+        <a href="/member/logout"> 로그아웃 </a>
+        <dr/>
+        <hr/>
+    </div>
 
 </body>
 </html>


### PR DESCRIPTION
Changes  
---  

- 카테고리 목록 출력 화면 (`admin/category/list.html`) 구현  
- 카테고리 추가 폼 및 저장 로직 구현  
- 카테고리 수정 기능 추가 (화면 내 인라인 편집)  
- 카테고리 삭제 기능 추가 (사용 여부 변경 또는 실제 삭제)  
- 카테고리 정렬 순서 입력 및 변경 처리  
- Category 엔티티, DTO, Mapper, Service 전체 구성  

Description  
---  

관리자가 카테고리를 직접 관리할 수 있도록  
카테고리 목록 출력, 추가, 수정, 삭제, 정렬 기능을 한 화면에서 구현하였습니다.

- 카테고리별 ID, 명칭, 우선순위, 사용 여부를 테이블로 출력  
- 각 행에서 직접 편집하거나 삭제 가능  
- 정렬 기준(우선순위)을 수동으로 변경 가능  
- 변경 사항은 모두 DB에 반영되며, 재조회 시 정렬 순서 유지됨  
- 전체 기능은 관리자 전용 메뉴에서 접근 가능  