### PR TITLE
feature/course-detail

### DIFF
--- a/src/main/java/com/zerobase/fastlms/course/dto/CourseDto.java
+++ b/src/main/java/com/zerobase/fastlms/course/dto/CourseDto.java
@@ -1,13 +1,23 @@
 package com.zerobase.fastlms.course.dto;
 
+import com.zerobase.fastlms.course.entity.Course;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Data
 public class CourseDto {
 
     Long id;
+
+    long categoryId;
 
     String imagePath;
     String keyword;
@@ -17,7 +27,7 @@ public class CourseDto {
     String contents;
     long price;
     long salePrice;
-    LocalDateTime saleEndDt;
+    LocalDate saleEndDt;
 
     LocalDateTime regDt; // 등록일(추가 날짜)
     LocalDateTime udtDt; // 수정일(수정 날짜)
@@ -25,4 +35,21 @@ public class CourseDto {
     // 추가컬럼
     long totalCount;
     long seq;
+
+    public static CourseDto of(Course course) {
+        return CourseDto.builder()
+                .id(course.getId())
+                .categoryId(course.getCategoryId())
+                .imagePath(course.getImagePath())
+                .keyword(course.getKeyword())
+                .subject(course.getSubject())
+                .summary(course.getSummary())
+                .contents(course.getContents())
+                .price(course.getPrice())
+                .salePrice(course.getSalePrice())
+                .saleEndDt(course.getSaleEndDt())
+                .regDt(course.getRegDt())
+                .udtDt(course.getUdtDt())
+                .build();
+    }
 }

--- a/src/main/java/com/zerobase/fastlms/course/entity/Course.java
+++ b/src/main/java/com/zerobase/fastlms/course/entity/Course.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Builder
@@ -19,6 +20,8 @@ public class Course {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
+    long categoryId;
+
     String imagePath;
     String keyword;
     String subject;
@@ -30,7 +33,7 @@ public class Course {
     String contents;
     long price;
     long salePrice;
-    LocalDateTime saleEndDt;
+    LocalDate saleEndDt;
 
     LocalDateTime regDt; // 등록일(추가 날짜)
     LocalDateTime udtDt; // 수정일(수정 날짜)

--- a/src/main/java/com/zerobase/fastlms/course/model/CourseInput.java
+++ b/src/main/java/com/zerobase/fastlms/course/model/CourseInput.java
@@ -5,6 +5,14 @@ import lombok.Data;
 @Data
 public class CourseInput {
 
+    long id;
+    long categoryId;
     String subject;
+    String keyword;
+    String summary;
+    String contents;
+    long price;
+    long salePrice;
+    String saleEndDtText;
 
 }

--- a/src/main/java/com/zerobase/fastlms/course/service/CourseService.java
+++ b/src/main/java/com/zerobase/fastlms/course/service/CourseService.java
@@ -14,7 +14,17 @@ public interface CourseService {
     boolean add(CourseInput parameter);
 
     /**
+     * 강좌 정보수정
+     */
+    boolean set(CourseInput parameter);
+
+    /**
      * 강좌 목록
      */
     List<CourseDto> list(CourseParam parameter);
+
+    /**
+     * 강좌 상세정보
+     */
+    CourseDto getById(long id);
 }

--- a/src/main/java/com/zerobase/fastlms/course/service/CourseServiceImpl.java
+++ b/src/main/java/com/zerobase/fastlms/course/service/CourseServiceImpl.java
@@ -10,23 +10,73 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
-public class CourseServiceImpl implements  CourseService {
+public class CourseServiceImpl implements CourseService {
 
     private final CourseRepository courseRepository;
     private final CourseMapper courseMapper;
 
+    private LocalDate getLocalDate(String value) {
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        try {
+            return LocalDate.parse(value, formatter);
+        } catch (Exception e) {
+        }
+
+        return null;
+    }
+
     @Override
     public boolean add(CourseInput parameter) {
 
+        LocalDate saleEndDt = getLocalDate(parameter.getSaleEndDtText());
+
         Course course = Course.builder()
+                .categoryId(parameter.getCategoryId())
                 .subject(parameter.getSubject())
-                .regDt(LocalDateTime.now() )
+                .keyword(parameter.getKeyword())
+                .summary(parameter.getSummary())
+                .price(parameter.getPrice())
+                .salePrice(parameter.getSalePrice())
+                .saleEndDt(saleEndDt)
+                .regDt(LocalDateTime.now())
                 .build();
+        courseRepository.save(course);
+
+        return true;
+    }
+
+    @Override
+    public boolean set(CourseInput parameter) {
+
+        LocalDate saleEndDt = getLocalDate(parameter.getSaleEndDtText());
+
+        Optional<Course> courseOptional = courseRepository.findById(parameter.getId());
+        if (!courseOptional.isPresent()) {
+            // 수정할 데이터가 없음
+            return false;
+        }
+
+        Course course = courseOptional.get();
+        course.setCategoryId(parameter.getCategoryId());
+        course.setSubject(parameter.getSubject());
+        course.setKeyword(parameter.getKeyword());
+        course.setSummary(parameter.getSummary());
+        course.setContents(parameter.getContents());
+        course.setPrice(parameter.getPrice());
+        course.setSalePrice(parameter.getSalePrice());
+        course.setSaleEndDt(saleEndDt);
+        course.setUdtDt(LocalDateTime.now());
+
         courseRepository.save(course);
 
         return true;
@@ -48,5 +98,12 @@ public class CourseServiceImpl implements  CourseService {
         }
 
         return list;
+    }
+
+    @Override
+    public CourseDto getById(long id) {
+
+        return courseRepository.findById(id).map(CourseDto::of).orElse(null);
+
     }
 }

--- a/src/main/resources/mybatis/CourseMapper.xml
+++ b/src/main/resources/mybatis/CourseMapper.xml
@@ -51,7 +51,7 @@
         from course
         where 1 = 1
             <include refid="selectListWhere"></include>
-
+        order by reg_dt desc
         limit #{pageStart}, #{pageEnd}
     </select>
 </mapper>

--- a/src/main/resources/templates/admin/category/list.html
+++ b/src/main/resources/templates/admin/category/list.html
@@ -90,7 +90,6 @@
                         <input type="hidden" th:value="${x.id}" name="id"/>
                         <p th:text="${x.id}">1</p>
                     </td>
-
                     <td>
                         <input th:value="${x.categoryName}" type="text" name="categoryName"/>"
                     </td>

--- a/src/main/resources/templates/admin/course/add.html
+++ b/src/main/resources/templates/admin/course/add.html
@@ -44,17 +44,86 @@
             <table>
                 <tbody>
                     <tr>
+                        <th>강좌 카테고리</th>
+                        <td>
+                            <select name="categoryId" required>
+                                <option value=""> 카테고리 선택 </option>
+                                <option
+                                        th:selected="${detail.categoryId == x.id}"
+                                        th:each="x : ${category}" th:value="${x.id}" th:text="${x.categoryName}"> 기획 </option>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
                         <th>
-                            강좌명:
+                            강좌명
                         </th>
                         <td>
-                            <input type="text" name="subject" required placeholder="강좌명 입력"/>
+                            <input th:value="${detail.subject}" type="text" name="subject" required placeholder="강좌명 입력"/>
                         </td>
+                    </tr>
+
+                    <tr>
+                        <th>
+                            키워드
+                        </th>
+                        <td>
+                            <input th:value="${detail.keyword}" type="text" name="keyword" required placeholder="키워드 입력"/>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <th>
+                            요약문구
+                        </th>
+                        <td>
+                            <input th:text="${detail.summary}" type="text" name="summary" required placeholder="요약문구 입력"/>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <th>
+                            내용
+                        </th>
+                        <td>
+                            <input th:text="${detail.contents}" type="text" name="contents" required placeholder="내용 입력"/>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <th>
+                            정가
+                        </th>
+                        <td>
+                            <input th:value="${detail.price}" type="text" name="price" required placeholder="정가 입력"/>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <th>
+                            판매가
+                        </th>
+                        <td>
+                            <input th:value="${detail.salePrice}" type="text" name="salePrice" required placeholder="판매가 입력"/>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <th>
+                            할인 종료일
+                        </th>
+                        <td>
+                            <input th:value="${detail.saleEndDt}" type="text" name="saleEndDtText" placeholder="할인 종료일 입력"/>
+                        </td>
+                    </tr>
+
+
                 </tbody>
             </table>
 
             <div class="buttons">
-                <button type="submit"> 강좌 등록 하기 </button>
+                <button th:if="${editMode}" type="submit"> 강좌 수정 하기 </button>
+                <button th:if="${!editMode}" type="submit"> 강좌 등록 하기 </button>
                 <a href="admin/course/list.do"> 목록 이동 </a>
             </div>
 

--- a/src/main/resources/templates/admin/course/list.html
+++ b/src/main/resources/templates/admin/course/list.html
@@ -63,7 +63,9 @@
                 <tr th:each="x : ${list}">
                     <td th:text="${x.seq}">1</td>
                     <td>
-                        <p th:text="${x.subjedt}"></p>
+                        <p>
+                            <a th:href="'edit.do?id=' + ${x.id}" th:text="${x.subjedt}">강좌명</a>
+                        </p>
                     </td>
                     <td th:text="${x.userName}">홍길동</td>
                     <td th:text="${x.phone}">010-1111-2222</td>

--- a/src/main/resources/templates/common/error.html
+++ b/src/main/resources/templates/common/error.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>에러 화면</title>
+</head>
+<body>
+    <h1>에러 화면</h1>
+
+    <p th:text="${message}"></p>
+
+    <div>
+        <a href="/">홈으로 이동</a>
+    </div>
+
+</body>
+</html>


### PR DESCRIPTION
Changes  
---  

- 강좌 상세 정보 페이지 구현  
- 강좌 수정 기능 추가 (기존 데이터 조회 후 수정 저장)  
- 상태값 (공개/비공개 등) 포함된 폼 구성  
- 등록일, 제목, 카테고리 등의 수정 가능  

Description  
---  

강좌 정보를 상세히 조회하고 수정할 수 있도록  
상세 페이지 및 수정 기능을 구현했습니다.

- 기존 등록된 강좌 정보가 폼에 자동 반영되며  
- 수정 후 저장 시 DB에 업데이트 처리됩니다.  