### PR TITLE
feat: course-management-ui-and-apply

### DIFF
--- a/result.json
+++ b/result.json
@@ -1,0 +1,9 @@
+{
+  "header": {
+    "result": false,
+    "message": ""
+  },
+  "body": {
+
+  }
+}

--- a/src/main/java/com/zerobase/fastlms/admin/dto/CategoryDto.java
+++ b/src/main/java/com/zerobase/fastlms/admin/dto/CategoryDto.java
@@ -20,6 +20,9 @@ public class CategoryDto {
     int sortValue;
     boolean usingYn;
 
+    // ADD COLUMNS
+    int courseCount;
+
     public static List<CategoryDto> of(List<Category> categories) {
         if (categories != null) {
             List<CategoryDto> categoryList = new ArrayList<>();

--- a/src/main/java/com/zerobase/fastlms/admin/mapper/CategoryMapper.java
+++ b/src/main/java/com/zerobase/fastlms/admin/mapper/CategoryMapper.java
@@ -1,0 +1,13 @@
+package com.zerobase.fastlms.admin.mapper;
+
+import com.zerobase.fastlms.admin.dto.CategoryDto;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface CategoryMapper {
+
+    List<CategoryDto> select(CategoryDto parameter);
+
+}

--- a/src/main/java/com/zerobase/fastlms/admin/service/CategoryService.java
+++ b/src/main/java/com/zerobase/fastlms/admin/service/CategoryService.java
@@ -2,6 +2,8 @@ package com.zerobase.fastlms.admin.service;
 
 import com.zerobase.fastlms.admin.dto.CategoryDto;
 import com.zerobase.fastlms.admin.model.CategoryInput;
+import com.zerobase.fastlms.course.dto.CourseDto;
+import com.zerobase.fastlms.course.model.CourseParam;
 
 import java.util.List;
 
@@ -23,4 +25,9 @@ public interface CategoryService {
      * 카테고리 삭제
      */
     boolean del(long id);
+
+    /**
+     * 프론트 카테고리 정보
+     */
+    List<CategoryDto> frontList(CategoryDto parameter);
 }

--- a/src/main/java/com/zerobase/fastlms/admin/service/CategoryServiceImpl.java
+++ b/src/main/java/com/zerobase/fastlms/admin/service/CategoryServiceImpl.java
@@ -2,6 +2,7 @@ package com.zerobase.fastlms.admin.service;
 
 import com.zerobase.fastlms.admin.dto.CategoryDto;
 import com.zerobase.fastlms.admin.entity.Category;
+import com.zerobase.fastlms.admin.mapper.CategoryMapper;
 import com.zerobase.fastlms.admin.model.CategoryInput;
 import com.zerobase.fastlms.admin.repository.CategoryRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,8 +16,8 @@ import java.util.Optional;
 @Service
 public class CategoryServiceImpl implements CategoryService {
 
-
     private final CategoryRepository categoryRepository;
+    private final CategoryMapper categoryMapper;
 
     private Sort getSortBySortValueDesc() {
 
@@ -65,5 +66,11 @@ public class CategoryServiceImpl implements CategoryService {
         categoryRepository.deleteById(id);
 
         return true;
+    }
+
+    @Override
+    public List<CategoryDto> frontList(CategoryDto parameter) {
+
+        return categoryMapper.select(parameter);
     }
 }

--- a/src/main/java/com/zerobase/fastlms/common/model/ResponseResult.java
+++ b/src/main/java/com/zerobase/fastlms/common/model/ResponseResult.java
@@ -1,0 +1,17 @@
+package com.zerobase.fastlms.common.model;
+
+import lombok.Data;
+
+@Data
+public class ResponseResult {
+    ResponseResultHeader header;
+    Object body;
+
+    public ResponseResult(boolean result, String message) {
+    header = new ResponseResultHeader(result, message);
+    }
+
+    public ResponseResult(boolean result) {
+    header = new ResponseResultHeader(result);
+    }
+}

--- a/src/main/java/com/zerobase/fastlms/common/model/ResponseResultHeader.java
+++ b/src/main/java/com/zerobase/fastlms/common/model/ResponseResultHeader.java
@@ -1,0 +1,19 @@
+package com.zerobase.fastlms.common.model;
+
+import lombok.Data;
+
+@Data
+public class ResponseResultHeader {
+
+    boolean result;
+    String message;
+
+    public ResponseResultHeader(boolean result, String message) {
+        this.result = result;
+        this.message = message;
+    }
+
+    public ResponseResultHeader(boolean result) {
+        this.result = result;
+    }
+}

--- a/src/main/java/com/zerobase/fastlms/course/controller/ApiCourseController.java
+++ b/src/main/java/com/zerobase/fastlms/course/controller/ApiCourseController.java
@@ -1,0 +1,39 @@
+package com.zerobase.fastlms.course.controller;
+
+import com.zerobase.fastlms.common.model.ResponseResult;
+import com.zerobase.fastlms.course.model.ServiceResult;
+import com.zerobase.fastlms.course.model.TakeCourseInput;
+import com.zerobase.fastlms.course.service.CourseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.security.Principal;
+
+@Controller
+@RequiredArgsConstructor
+public class ApiCourseController extends BaseController {
+
+    private final CourseService courseService;
+
+    @PostMapping("/api/course/req.api")
+    public ResponseEntity<?> courseReq(Model model
+            , @RequestBody TakeCourseInput parameter, Principal principal) {
+
+        parameter.setUserId(principal.getName());
+
+        ServiceResult result = courseService.req(parameter);
+        if (!result.isResult()) {
+            ResponseResult responseResult = new ResponseResult(false, result.getMessage());
+            return ResponseEntity.ok().body(responseResult);
+        }
+
+        ResponseResult responseResult = new ResponseResult(true);
+        return ResponseEntity.ok().body(responseResult);
+    }
+
+
+}

--- a/src/main/java/com/zerobase/fastlms/course/controller/CourseController.java
+++ b/src/main/java/com/zerobase/fastlms/course/controller/CourseController.java
@@ -1,0 +1,54 @@
+package com.zerobase.fastlms.course.controller;
+
+import com.zerobase.fastlms.admin.dto.CategoryDto;
+import com.zerobase.fastlms.admin.service.CategoryService;
+import com.zerobase.fastlms.course.dto.CourseDto;
+import com.zerobase.fastlms.course.model.CourseParam;
+import com.zerobase.fastlms.course.service.CourseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class CourseController extends BaseController {
+
+    private final CourseService courseService;
+    private final CategoryService categoryService;
+
+    @GetMapping("/course")
+    public String course(Model model
+            , CourseParam parameter) {
+
+        List<CourseDto> list = courseService.frontList(parameter);
+        model.addAttribute("list", list);
+
+        int courseTotalCount = 0;
+        List<CategoryDto> categoryList = categoryService.frontList(CategoryDto.builder().build());
+        if (categoryList != null) {
+            for (CategoryDto x : categoryList) {
+                courseTotalCount += x.getCourseCount();
+            }
+        }
+
+        model.addAttribute("categoryList", categoryList);
+        model.addAttribute("courseTotalCount", courseTotalCount);
+
+        return "course/index";
+    }
+
+    @GetMapping("/course/{id}")
+    public String courseDetail(Model model
+            , CourseParam parameter) {
+
+        CourseDto detail = courseService.frontDetail(parameter.getId());
+        model.addAttribute("detail", detail);
+
+        return "course/detail";
+    }
+
+}

--- a/src/main/java/com/zerobase/fastlms/course/dto/CourseDto.java
+++ b/src/main/java/com/zerobase/fastlms/course/dto/CourseDto.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Builder
 @NoArgsConstructor
@@ -51,5 +53,20 @@ public class CourseDto {
                 .regDt(course.getRegDt())
                 .udtDt(course.getUdtDt())
                 .build();
+    }
+
+    public static List<CourseDto> of(List<Course> courses) {
+
+        if (courses == null) {
+            return null;
+
+        }
+
+        List<CourseDto> courseList = new ArrayList<>();
+        for (Course x : courses) {
+            courseList.add(CourseDto.of(x));
+        }
+
+        return courseList;
     }
 }

--- a/src/main/java/com/zerobase/fastlms/course/entity/TakeCourse.java
+++ b/src/main/java/com/zerobase/fastlms/course/entity/TakeCourse.java
@@ -1,0 +1,31 @@
+package com.zerobase.fastlms.course.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Entity
+public class TakeCourse implements TakeCourseCode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    long courseId;
+    String userId;
+
+    long payPrice; // 결제금액
+    String status;// 상태(수강신청/결제완료/수강취소)
+
+    LocalDateTime regDt; // 신청일
+
+}

--- a/src/main/java/com/zerobase/fastlms/course/entity/TakeCourseCode.java
+++ b/src/main/java/com/zerobase/fastlms/course/entity/TakeCourseCode.java
@@ -1,0 +1,9 @@
+package com.zerobase.fastlms.course.entity;
+
+public interface TakeCourseCode {
+
+    String STATUS_REQ = "REQ"; // 수강 신청
+    String STATUS_COMPLETE = "COMPLETE"; // 결제 완료
+    String STATUS_CANCEL = "CANCEL"; // 수강 취소
+
+}

--- a/src/main/java/com/zerobase/fastlms/course/model/CourseParam.java
+++ b/src/main/java/com/zerobase/fastlms/course/model/CourseParam.java
@@ -6,4 +6,7 @@ import lombok.Data;
 @Data
 public class CourseParam extends CommonParam {
 
+    long id;
+    long categoryId;
+
 }

--- a/src/main/java/com/zerobase/fastlms/course/model/ServiceResult.java
+++ b/src/main/java/com/zerobase/fastlms/course/model/ServiceResult.java
@@ -1,0 +1,11 @@
+package com.zerobase.fastlms.course.model;
+
+import lombok.Data;
+
+@Data
+public class ServiceResult {
+
+    boolean result;
+    String message;
+
+}

--- a/src/main/java/com/zerobase/fastlms/course/model/TakeCourseInput.java
+++ b/src/main/java/com/zerobase/fastlms/course/model/TakeCourseInput.java
@@ -1,0 +1,11 @@
+package com.zerobase.fastlms.course.model;
+
+import lombok.Data;
+
+@Data
+public class TakeCourseInput {
+
+    long courseId;
+    String userId;
+
+}

--- a/src/main/java/com/zerobase/fastlms/course/repository/CourseRepository.java
+++ b/src/main/java/com/zerobase/fastlms/course/repository/CourseRepository.java
@@ -3,5 +3,11 @@ package com.zerobase.fastlms.course.repository;
 import com.zerobase.fastlms.course.entity.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface CourseRepository extends JpaRepository<Course, Long> {
+
+    Optional<List<Course>> findByCategoryId(long categoryId);
+
 }

--- a/src/main/java/com/zerobase/fastlms/course/repository/TakeCourseRepository.java
+++ b/src/main/java/com/zerobase/fastlms/course/repository/TakeCourseRepository.java
@@ -1,0 +1,16 @@
+package com.zerobase.fastlms.course.repository;
+
+import com.zerobase.fastlms.course.entity.Course;
+import com.zerobase.fastlms.course.entity.TakeCourse;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface TakeCourseRepository extends JpaRepository<TakeCourse, Long> {
+
+
+
+
+    long countByCourseIdAndUserIdAndStatusIn(Long courseId, String userId, Collection<String> statuses);
+}

--- a/src/main/java/com/zerobase/fastlms/course/service/CourseService.java
+++ b/src/main/java/com/zerobase/fastlms/course/service/CourseService.java
@@ -3,6 +3,8 @@ package com.zerobase.fastlms.course.service;
 import com.zerobase.fastlms.course.dto.CourseDto;
 import com.zerobase.fastlms.course.model.CourseInput;
 import com.zerobase.fastlms.course.model.CourseParam;
+import com.zerobase.fastlms.course.model.ServiceResult;
+import com.zerobase.fastlms.course.model.TakeCourseInput;
 
 import java.util.List;
 
@@ -32,4 +34,19 @@ public interface CourseService {
      * 강좌 내용 삭제
      */
     boolean del(String idList);
+
+    /**
+     * 프론트 강좌 목록
+     */
+    List<CourseDto> frontList(CourseParam parameter);
+
+    /**
+     * 프론트 강좌 상세 정보
+     */
+    CourseDto frontDetail(long id);
+
+    /**
+     * 수강 신청
+     */
+    ServiceResult req(TakeCourseInput parameter);
 }

--- a/src/main/java/com/zerobase/fastlms/course/service/CourseServiceImpl.java
+++ b/src/main/java/com/zerobase/fastlms/course/service/CourseServiceImpl.java
@@ -2,10 +2,14 @@ package com.zerobase.fastlms.course.service;
 
 import com.zerobase.fastlms.course.dto.CourseDto;
 import com.zerobase.fastlms.course.entity.Course;
+import com.zerobase.fastlms.course.entity.TakeCourse;
 import com.zerobase.fastlms.course.mapper.CourseMapper;
 import com.zerobase.fastlms.course.model.CourseInput;
 import com.zerobase.fastlms.course.model.CourseParam;
+import com.zerobase.fastlms.course.model.ServiceResult;
+import com.zerobase.fastlms.course.model.TakeCourseInput;
 import com.zerobase.fastlms.course.repository.CourseRepository;
+import com.zerobase.fastlms.course.repository.TakeCourseRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
@@ -13,6 +17,7 @@ import org.springframework.util.CollectionUtils;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,6 +26,7 @@ import java.util.Optional;
 public class CourseServiceImpl implements CourseService {
 
     private final CourseRepository courseRepository;
+    private final TakeCourseRepository takeCourseRepository;
     private final CourseMapper courseMapper;
 
     private LocalDate getLocalDate(String value) {
@@ -127,5 +133,70 @@ public class CourseServiceImpl implements CourseService {
         }
 
         return true;
+    }
+
+    @Override
+    public List<CourseDto> frontList(CourseParam parameter) {
+
+        if (parameter.getCategoryId() < 1) {
+            List<Course> courseList = courseRepository.findAll();
+            return CourseDto.of(courseList);
+        }
+        Optional<List<Course>> optionalCourses = courseRepository.findByCategoryId(parameter.getCategoryId());
+        if (optionalCourses.isPresent()) {
+            return CourseDto.of(optionalCourses.get());
+        }
+        return null;
+    }
+
+    @Override
+    public CourseDto frontDetail(long id) {
+
+        Optional<Course> optionalCourse = courseRepository.findById(id);
+        if (optionalCourse.isPresent()) {
+            return CourseDto.of(optionalCourse.get());
+        }
+        return null;
+
+
+    }
+
+    @Override
+    public ServiceResult req(TakeCourseInput parameter) {
+
+        ServiceResult result = new ServiceResult();
+
+        Optional<Course> optionalCourse = courseRepository.findById(parameter.getCourseId());
+        if (!optionalCourse.isPresent()) {
+            result.setResult(false);
+            result.setMessage("강좌 정보가 존재하지 않습니다.");
+            return  result;
+        }
+
+        Course course = optionalCourse.get();
+
+        // 이미 신청정보가 있는지 확인
+        String[] statusList = {TakeCourse.STATUS_REQ, TakeCourse.STATUS_COMPLETE};
+        long count = takeCourseRepository.countByCourseIdAndUserIdAndStatusIn(course.getId(), parameter.getUserId(), Arrays.asList(statusList));
+
+        if (count > 0) {
+            result.setResult(false);
+            result.setMessage("이미 신청한 강좌 정보가 존재합니다.");
+            return  result;
+        }
+
+        TakeCourse takeCourse = TakeCourse.builder()
+                .courseId(course.getId())
+                .userId(parameter.getUserId())
+                .payPrice(course.getSalePrice())
+                .regDt(LocalDateTime.now())
+                .status(TakeCourse.STATUS_REQ)
+                .build();
+        takeCourseRepository.save(takeCourse);
+
+        result.setResult(true);
+        result.setMessage("");
+
+        return result;
     }
 }

--- a/src/main/resources/mybatis/CategoryMapper.xml
+++ b/src/main/resources/mybatis/CategoryMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0/KO"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.zerobase.fastlms.admin.mapper.CategoryMapper">
+
+    <select id="select" resultType="com.zerobase.fastlms.admin.dto.CategoryDto">
+
+        select c.*
+             , (select count(*) from course where category_id = c.id) as course_count
+        from category c
+        where using_yn = 1
+        order by sort_value desc
+
+    </select>
+
+</mapper>

--- a/src/main/resources/templates/course/detail.html
+++ b/src/main/resources/templates/course/detail.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="ko">`
+<head>
+    <meta charset="UTF-8" xmlns:th="http://www.thymeleaf.org">
+    <title>강좌 상세 페이지</title>
+    <style>
+        span.price {
+            text-decoration: line-through;
+        }
+    </style>
+
+    <script src="https://cdn.isdelivr.net/npm/axios/dist/axios.min.is"></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"
+            integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
+    <script>
+        $(function () {
+
+            $('#submitForm').on('submit', function () {
+
+                var $this = $(this);
+
+                var url = 'api/course/req.api';
+                var parameter = {
+                    courseId: $thisForm.find('input[name=id]').val()
+                };
+                axios.post(url, parameter).then(function (response) {
+                    console.log(response);
+                    console.log(response.data);
+
+                    response.data = response.data || {};
+                    response.data.header = response.data.header || {};
+
+                    if (!response.data.header.result) {
+                        alert(response.data.header.message);
+                        return false;
+                    }
+
+                    alert(' 강좌가 정상적으로 신청되었습니다. ');
+                    location.href = '/';
+
+                }).catch(function (err) {
+                    console.log(err);
+                });
+
+                return false;
+            });
+        });
+    </script>
+</head>
+<body>
+    <h1> 강좌 상세 정보 </h1>
+    <div th:replace="/fragments/layout.html :: fragment-body-menu"></div>
+
+    <div>
+        <h2>강좌명: <span th:text="${detail.subject}">강좌</span></h2>
+        <div th:text="${detail.contents}">
+        </div>
+        <div>
+            <p>가격: <span th:text="${detail.subject}">강좌</span></p>
+            <p>할인가격: <span th:text="${detail.subject}">0</span></p>
+        </div>
+
+        <div>
+            <form id="submitForm" method="post">
+                <input type="hidden" name="id" th:value="${detail.id}">
+                <button type="button">수강신청</button>
+                <a href="/course">강좌목록</a>
+            </form>
+        </div>
+    </div>
+
+</body>
+</html>

--- a/src/main/resources/templates/course/index.html
+++ b/src/main/resources/templates/course/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="ko">`
+<head>
+    <meta charset="UTF-8" xmlns:th="http://www.thymeleaf.org">
+    <title>강좌 정보 페이지</title>
+    <style>
+        span.price {
+            text-decoration: line-through;
+        }
+    </style>
+</head>
+<body>
+<h1> 강좌 목록 </h1>
+<div th:replace="/fragments/layout.html :: fragment-body-menu"></div>
+
+<div>
+    <a href="?">
+        전체 (<span th:text="${courseTotalCount}">0</span>)
+    </a>
+
+    <th:block th:each="y : ${categoryList}">
+        |
+        <a th:href="'/course?categoryId=' + ${y.id}">
+            <span th:text="${y.categoryName}">카테고리명</span> (<span th:text="${y.courseCount}">0</span>)</a>
+    </th:block>
+
+    </hr>
+</div>
+
+<ul>
+    <li th:each="x : ${list}">
+        <div>
+            <a th:href="'/course/' + ${x.id}">
+                <h3 th:text="${x.subject}">강좌명</h3>
+            </a>
+            <div>
+                <p th:text="${x.summary}"></p>
+                <p>
+                    판매가: <span class="price" th:text="${x.price}"></span>
+                    할인가: <span th:text="${x.salePrice}"></span>
+                </p>
+            </div>
+        </div>
+
+    </li>
+</ul>
+
+</body>
+</html>

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -12,6 +12,8 @@
             |
             <a href="/member/info"> 회원 정보 </a>
             |
+            <a href="//course"> 강좌 목록 </a>
+            |
             <a href="/member/login"> 로그인 </a>
             |
             <a href="/member/logout"> 로그아웃 </a>

--- a/src/main/resources/templates/member/login.html
+++ b/src/main/resources/templates/member/login.html
@@ -24,7 +24,7 @@
     </form>
 
     <div>
-        <a href="/member/find/password">비밀번호 찾기</a>
+        <a href="/member/find_password">비밀번호 찾기</a>
     </div>
 
 </body>


### PR DESCRIPTION
### Changes
---

- 강좌 목록 UI + 페이징 처리
- 강좌 상세 정보 페이지
- 강좌 신청 처리 로직 및 DB 연동
- Thymeleaf 템플릿 및 뷰 흐름 구성

### Description
---

- 사용자는 강좌를 목록에서 조회하고, 상세 내용을 확인한 뒤, 신청까지 진행할 수 있습니다.
- /course → /course/detail/{id} → /course/apply 흐름으로 구성되어 있습니다.

### Context
---

- 강좌 정보를 사용자에게 보여주고 신청까지 할 수 있는 기본적인 학습 흐름 구축