### PR TITLE
feat: member-info-update

### DIFF
--- a/src/main/java/com/zerobase/fastlms/course/dto/TakeCourseDto.java
+++ b/src/main/java/com/zerobase/fastlms/course/dto/TakeCourseDto.java
@@ -1,10 +1,16 @@
 package com.zerobase.fastlms.course.dto;
 
+import com.zerobase.fastlms.course.entity.TakeCourse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Data
 public class TakeCourseDto {
 
@@ -25,6 +31,18 @@ public class TakeCourseDto {
     // 추가 컬럼
     long totalCount;
     long seq;
+
+    public static TakeCourseDto of(TakeCourse x) {
+
+        return TakeCourseDto.builder()
+                .id(x.getId())
+                .courseId(x.getCourseId())
+                .userId(x.getUserId())
+                .payPrice(x.getPayPrice())
+                .status(x.getStatus())
+                .regDt(x.getRegDt())
+                .build();
+    }
 
     public String getRegDtText() {
 

--- a/src/main/java/com/zerobase/fastlms/course/model/TakeCourseInput.java
+++ b/src/main/java/com/zerobase/fastlms/course/model/TakeCourseInput.java
@@ -8,4 +8,5 @@ public class TakeCourseInput {
     long courseId;
     String userId;
 
+    long takeCourseId;
 }

--- a/src/main/java/com/zerobase/fastlms/course/service/TakeCourseService.java
+++ b/src/main/java/com/zerobase/fastlms/course/service/TakeCourseService.java
@@ -14,6 +14,11 @@ public interface TakeCourseService {
     List<TakeCourseDto> list(TakeCourseParam parameter);
 
     /**
+     * 수강 상세 정보
+     */
+    TakeCourseDto detail(long id);
+
+    /**
      * 수강 내용 상태 변경
      */
     ServiceResult updateStatus(long id, String status);
@@ -22,4 +27,9 @@ public interface TakeCourseService {
      * 내 수강내역 목록
      */
     List<TakeCourseDto> myCourse(String userId);
+
+    /**
+     * 수강 신청 취소 처리
+     */
+    ServiceResult cancel(long id);
 }

--- a/src/main/java/com/zerobase/fastlms/course/service/TakeCourseServiceImpl.java
+++ b/src/main/java/com/zerobase/fastlms/course/service/TakeCourseServiceImpl.java
@@ -2,6 +2,7 @@ package com.zerobase.fastlms.course.service;
 
 import com.zerobase.fastlms.course.dto.TakeCourseDto;
 import com.zerobase.fastlms.course.entity.TakeCourse;
+import com.zerobase.fastlms.course.entity.TakeCourseCode;
 import com.zerobase.fastlms.course.mapper.TakeCourseMapper;
 import com.zerobase.fastlms.course.model.ServiceResult;
 import com.zerobase.fastlms.course.model.TakeCourseParam;
@@ -41,6 +42,17 @@ public class TakeCourseServiceImpl implements TakeCourseService {
     }
 
     @Override
+    public TakeCourseDto detail(long id) {
+
+        Optional<TakeCourse> optionalTakeCourse = takeCourseRepository.findById(id);
+        if (optionalTakeCourse.isPresent()) {
+            return TakeCourseDto.of(optionalTakeCourse.get());
+        }
+
+        return null;
+    }
+
+    @Override
     public ServiceResult updateStatus(long id, String status) {
 
         Optional<TakeCourse> optionalTakeCourse = takeCourseRepository.findById(id);
@@ -64,5 +76,21 @@ public class TakeCourseServiceImpl implements TakeCourseService {
         List<TakeCourseDto> list = takeCourseMapper.selectListMyCourse(parameter);
 
         return list;
+    }
+
+    @Override
+    public ServiceResult cancel(long id) {
+
+        Optional<TakeCourse> optionalTakeCourse = takeCourseRepository.findById(id);
+        if (!optionalTakeCourse.isPresent()) {
+            return new ServiceResult(false, "수강 정보가 존재하지 않습니다.");
+        }
+
+        TakeCourse takeCourse = optionalTakeCourse.get();
+
+        takeCourse.setStatus(TakeCourseCode.STATUS_CANCEL);
+        takeCourseRepository.save(takeCourse);
+
+        return new ServiceResult();
     }
 }

--- a/src/main/java/com/zerobase/fastlms/member/controller/ApiMemberController.java
+++ b/src/main/java/com/zerobase/fastlms/member/controller/ApiMemberController.java
@@ -1,0 +1,55 @@
+package com.zerobase.fastlms.member.controller;
+
+import com.zerobase.fastlms.common.model.ResponseResult;
+import com.zerobase.fastlms.course.dto.TakeCourseDto;
+import com.zerobase.fastlms.course.model.ServiceResult;
+import com.zerobase.fastlms.course.model.TakeCourseInput;
+import com.zerobase.fastlms.course.service.TakeCourseService;
+import com.zerobase.fastlms.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class ApiMemberController {
+
+    private final MemberService memberService;
+    private final TakeCourseService takeCourseService;
+
+    @PostMapping("/api/member/Course/cancel.api")
+    public ResponseEntity<?> cancelCourse(Model model,
+                                          @RequestBody TakeCourseInput parameter,
+                                          Principal principal) {
+
+        String userId = principal.getName();
+
+        // 내 강좌인지 확인
+        TakeCourseDto detail = takeCourseService.detail(parameter.getTakeCourseId());
+        if (detail == null) {
+            ResponseResult responseResult = new ResponseResult(false, "수강 신청 정보가 존재하지 않습니다.");
+            return ResponseEntity.ok().body(responseResult);
+        }
+
+        if (userId == null || userId.equals(detail.getUserId())) {
+            // 내 수강신청 정보가 아닌 경우
+            ResponseResult responseResult = new ResponseResult(false, "본인의 수강 신청 정보만 취소 할 수 있습니다.");
+            return ResponseEntity.ok().body(responseResult);
+        }
+
+        ServiceResult result = takeCourseService.cancel(parameter.getCourseId());
+        if (!result.isResult()) {
+            ResponseResult responseResult = new ResponseResult(false, result.getMessage());
+            return ResponseEntity.ok().body(responseResult);
+        }
+
+        ResponseResult responseResult = new ResponseResult(true);
+        return ResponseEntity.ok().body(responseResult);
+    }
+}

--- a/src/main/java/com/zerobase/fastlms/member/controller/MemberController.java
+++ b/src/main/java/com/zerobase/fastlms/member/controller/MemberController.java
@@ -165,4 +165,27 @@ public class MemberController {
 
         return "member/reset_password_result";
     }
+
+    @GetMapping("/withdraw")
+    public String memberWithdraw(Model model) {
+
+        return "member/withdraw";
+    }
+
+    @PostMapping("/withdraw")
+    public String memberWithdrawSubmit(Model model,
+                                       MemberInput parameter,
+                                       Principal principal) {
+
+        String userId = principal.getName();
+
+        ServiceResult result = memberService.withdraw(userId, parameter.getPassword());
+
+        if (!result.isResult()) {
+            model.addAttribute("message", result.getMessage());
+            return "common/error";
+        }
+
+        return "redirect:/member/logout";
+    }
 }

--- a/src/main/java/com/zerobase/fastlms/member/entity/MemberCode.java
+++ b/src/main/java/com/zerobase/fastlms/member/entity/MemberCode.java
@@ -16,4 +16,9 @@ public interface MemberCode {
      * 현재 정지된 상태
      */
     String MEMBER_STATUS_STOP = "STOP";
+
+    /**
+     * 현재 탈퇴된 상태
+     */
+    String MEMBER_STATUS_WITHDRAW = "WITHDRAW";
 }

--- a/src/main/java/com/zerobase/fastlms/member/service/MemberService.java
+++ b/src/main/java/com/zerobase/fastlms/member/service/MemberService.java
@@ -63,4 +63,8 @@ public interface MemberService extends UserDetailsService {
      */
     ServiceResult updateMemberPassword(MemberInput parameter);
 
+    /**
+     * 회원 탈퇴 로직
+     */
+    ServiceResult withdraw(String userId, String password);
 }

--- a/src/main/java/com/zerobase/fastlms/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/zerobase/fastlms/member/service/impl/MemberServiceImpl.java
@@ -6,12 +6,14 @@ import com.zerobase.fastlms.admin.model.MemberParam;
 import com.zerobase.fastlms.components.MailComponents;
 import com.zerobase.fastlms.course.model.ServiceResult;
 import com.zerobase.fastlms.member.entity.Member;
+import com.zerobase.fastlms.member.entity.MemberCode;
 import com.zerobase.fastlms.member.exception.MemberNotEmailAuthException;
 import com.zerobase.fastlms.member.exception.MemberStopUserException;
 import com.zerobase.fastlms.member.model.MemberInput;
 import com.zerobase.fastlms.member.model.ResetPasswordInput;
 import com.zerobase.fastlms.member.repository.MemberRepository;
 import com.zerobase.fastlms.member.service.MemberService;
+import com.zerobase.fastlms.util.PasswordUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -269,15 +271,48 @@ public class MemberServiceImpl implements MemberService {
 
         Member member = optionalMember.get();
 
-        if (!BCrypt.checkpw(parameter.getPassword(), member.getPassword())) {
+        if (!PasswordUtils.equals(parameter.getPassword(), member.getPassword())) {
             return new ServiceResult(false, "비밀번호가 일치하지 않습니다.");
         }
 
-        String encPassword = BCrypt.hashpw(parameter.getPassword(), BCrypt.gensalt());
+        String encPassword = PasswordUtils.encPassword(parameter.getPassword());
         member.setPassword(encPassword);
         memberRepository.save(member);
 
-        return new ServiceResult(true, "");
+        return new ServiceResult(true);
+    }
+
+    @Override
+    public ServiceResult withdraw(String userId, String password) {
+
+        Optional<Member> optionalMember = memberRepository.findById(userId);
+        if (!optionalMember.isPresent()) {
+            return new ServiceResult(false, "회원 정보가 존재하지 않습니다.");
+        }
+
+        Member member = optionalMember.get();
+
+        if (!PasswordUtils.equals(password, member.getPassword())) {
+            return new ServiceResult(false, "비밀번호가 일치하지 않습니다.");
+        }
+
+        member.setUserName("삭제회원");
+        member.setPhone("");
+        member.setPassword("");
+        member.setRegDt(null);
+        member.setUptDt(null);
+        member.setEmailAuthYn(false);
+        member.setEmailAuthDt(null);
+        member.setEmailAuthKey("");
+        member.setResetPasswordKey(null);
+        member.setResetPasswordLimitDt(null);
+        member.setUserStatus(MemberCode.MEMBER_STATUS_WITHDRAW);
+        member.setZipcode("");
+        member.setAddr("");
+        member.setAddrDetail("");
+        memberRepository.save(member);
+
+        return new  ServiceResult();
     }
 
     @Override
@@ -296,6 +331,10 @@ public class MemberServiceImpl implements MemberService {
 
         if (Member.MEMBER_STATUS_STOP.equals(member.getUserStatus())) {
             throw new MemberStopUserException("정지된 회원 입니다.");
+        }
+
+        if (Member.MEMBER_STATUS_WITHDRAW.equals(member.getUserStatus())) {
+            throw new MemberStopUserException("탈퇴된 회원 입니다.");
         }
 
         List<GrantedAuthority> grantedAuthorities = new ArrayList<>();

--- a/src/main/java/com/zerobase/fastlms/util/PasswordUtils.java
+++ b/src/main/java/com/zerobase/fastlms/util/PasswordUtils.java
@@ -1,0 +1,24 @@
+package com.zerobase.fastlms.util;
+
+import org.springframework.security.crypto.bcrypt.BCrypt;
+
+public class PasswordUtils {
+
+    public static boolean equals(String plaintext, String hashed) {
+
+        if (plaintext == null || plaintext.length() < 1) {
+            return false;
+        }
+
+        return BCrypt.checkpw(plaintext, hashed);
+    }
+
+    public static String encPassword(String plaintext) {
+
+        if (plaintext == null || plaintext.length() < 1) {
+            return "";
+        }
+
+        return BCrypt.hashpw(plaintext,BCrypt.gensalt());
+    }
+}

--- a/src/main/resources/templates/member/info.html
+++ b/src/main/resources/templates/member/info.html
@@ -87,6 +87,8 @@
 
         <div>
             <button type="submit">수정</button>
+
+            <a href="/member/withdraw"> 회원 탈퇴 </a>
         </div>
     </form>
 </div>

--- a/src/main/resources/templates/member/takecourse.html
+++ b/src/main/resources/templates/member/takecourse.html
@@ -24,14 +24,37 @@
 
             $('.row-buttons button').on('click', function () {
 
-                var id = $(this).closest('div').find('input[name=id]').val();
+                var id = $(this).val();
 
                 var msg = '수강취소 처리 하시겠습니까?';
                 if (!confirm(msg)) {
                     return false;
                 }
 
+                var url = 'api/member/course/cancel.api';
+                var parameter = {
+                    takeCourseId: id
+                };
+                axios.post(url, parameter).then(function (response) {
+                    console.log(response);
+                    console.log(response.data);
 
+                    response.data = response.data || {};
+                    response.data.header = response.data.header || {};
+
+                    if (!response.data.header.result) {
+                        alert(response.data.header.message);
+                        return false;
+                    }
+
+                    alert(' 강좌가 정상적으로 취소되었습니다. ');
+                    location.reload()
+
+                }).catch(function (err) {
+                    console.log(err);
+                });
+
+                return false;
 
             });
 
@@ -89,8 +112,7 @@
                 </td>
                 <td>
                     <div class="row-buttons" th:if="${x.status eq 'REQ'}">
-                        <input type="hidden" name="id" th:value="${x.id}">
-                        <button type="button">수강취소 처리</button>
+                        <button type="button" th:value="${x.id}">수강취소 처리</button>
                     </div>
                 </td>
 

--- a/src/main/resources/templates/member/withdraw.html
+++ b/src/main/resources/templates/member/withdraw.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>회원 정보</title>
+
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
+    <script>
+        $(document).ready(function () {
+
+            $('#submitForm').on('submit', function () {
+
+
+            });
+        });
+    </script>
+
+</head>
+<body>
+
+    <h1>회원 탈퇴</h1>
+    <div th:replace="fragments/layout.html :: fragment-body-menu"></div>
+
+    <div>
+        <hr/>
+        <a href="/member/info"> 회원 정보 수정 </a>
+        |
+        <a href="/member/password"> 비밀 번호 변경 </a>
+        |
+        <a href="/member/takecourse"> 내 수강 목록 </a>
+        <hr/>
+    </div>
+
+    <div>
+
+        <p>
+            회원 탈퇴를 하면
+            서비스를 더 이상 이요하실 수 없습니다.
+            <br/>
+            회원 탈퇴를 진행하시겠습니까?
+        </p>
+
+        <form id="submitForm" method="post">
+        <div>
+            <input type="password" name="password" placeholder="현재 비밀번호 입력" required/>
+        </div>
+        <div>
+            <button type="submit">회원 탈퇴 하기</button>
+        </div>
+
+        </form>
+    </div>
+
+
+</body>
+</html>


### PR DESCRIPTION
### Changes
---

- REST API 기반 수강 신청 취소 기능 구현
- 회원 탈퇴 기능 구현

### Description
---

- REST API를 이용하여 수강 신청 취소 기능을 두 단계에 걸쳐 구현하였으며, 요청 시 서버에서 해당 수강 정보를 찾아 상태를 변경하도록 처리했습니다.
- 회원 탈퇴 기능은 마이페이지에서 직접 탈퇴 요청 시, 사용자 정보를 소프트 삭제하거나 탈퇴 상태로 전환되도록 구성했습니다.
- 요청에 대한 응답 및 예외 처리를 세분화하여 사용자 UX를 고려하였습니다.